### PR TITLE
Add WordPress admin menu stubs

### DIFF
--- a/wp-amc/app/Controllers/Admin/MenuController.php
+++ b/wp-amc/app/Controllers/Admin/MenuController.php
@@ -1,0 +1,59 @@
+<?php
+namespace WpAmc\Controllers\Admin;
+
+class MenuController
+{
+    public static function register()
+    {
+        add_menu_page(
+            __('Auto Multiple Choice', 'wp-amc'),
+            __('Auto Multiple Choice', 'wp-amc'),
+            'manage_options',
+            'wp-amc',
+            [self::class, 'prepare_exam'],
+            'dashicons-feedback',
+            6
+        );
+
+        add_submenu_page('wp-amc', __('Prepare Exam', 'wp-amc'), __('Prepare Exam', 'wp-amc'), 'manage_options', 'wp-amc', [self::class, 'prepare_exam']);
+        add_submenu_page('wp-amc', __('Scan Sheets', 'wp-amc'), __('Scan Sheets', 'wp-amc'), 'manage_options', 'wp-amc-scan', [self::class, 'scan_sheets']);
+        add_submenu_page('wp-amc', __('Manual Grading', 'wp-amc'), __('Manual Grading', 'wp-amc'), 'manage_options', 'wp-amc-grade', [self::class, 'manual_grading']);
+        add_submenu_page('wp-amc', __('Export Results', 'wp-amc'), __('Export Results', 'wp-amc'), 'manage_options', 'wp-amc-export', [self::class, 'export_results']);
+        add_submenu_page('wp-amc', __('Preferences', 'wp-amc'), __('Preferences', 'wp-amc'), 'manage_options', 'wp-amc-preferences', [self::class, 'preferences']);
+    }
+
+    public static function prepare_exam()
+    {
+        self::render('prepare');
+    }
+
+    public static function scan_sheets()
+    {
+        self::render('scan');
+    }
+
+    public static function manual_grading()
+    {
+        self::render('grade');
+    }
+
+    public static function export_results()
+    {
+        self::render('export');
+    }
+
+    public static function preferences()
+    {
+        self::render('preferences');
+    }
+
+    protected static function render($view)
+    {
+        $view_file = __DIR__ . '/../../Views/admin/' . $view . '.php';
+        if (file_exists($view_file)) {
+            include $view_file;
+        } else {
+            echo '<div class="wrap"><h1>' . esc_html__('View not found.', 'wp-amc') . '</h1></div>';
+        }
+    }
+}

--- a/wp-amc/app/Views/admin/export.php
+++ b/wp-amc/app/Views/admin/export.php
@@ -1,0 +1,1 @@
+<div class="wrap"><h1>Placeholder for export view</h1></div>

--- a/wp-amc/app/Views/admin/grade.php
+++ b/wp-amc/app/Views/admin/grade.php
@@ -1,0 +1,1 @@
+<div class="wrap"><h1>Placeholder for grade view</h1></div>

--- a/wp-amc/app/Views/admin/preferences.php
+++ b/wp-amc/app/Views/admin/preferences.php
@@ -1,0 +1,1 @@
+<div class="wrap"><h1>Placeholder for preferences view</h1></div>

--- a/wp-amc/app/Views/admin/prepare.php
+++ b/wp-amc/app/Views/admin/prepare.php
@@ -1,0 +1,1 @@
+<div class="wrap"><h1>Placeholder for prepare view</h1></div>

--- a/wp-amc/app/Views/admin/scan.php
+++ b/wp-amc/app/Views/admin/scan.php
@@ -1,0 +1,1 @@
+<div class="wrap"><h1>Placeholder for scan view</h1></div>

--- a/wp-amc/wp-amc.php
+++ b/wp-amc/wp-amc.php
@@ -1,0 +1,14 @@
+<?php
+/*
+Plugin Name: Auto Multiple Choice
+Description: Integrates Auto Multiple Choice tools into WordPress.
+*/
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once __DIR__ . '/app/Controllers/Admin/MenuController.php';
+
+// Initialize admin menu
+add_action('admin_menu', ['\WpAmc\Controllers\Admin\MenuController', 'register']);


### PR DESCRIPTION
## Summary
- add initial WordPress plugin skeleton
- register Auto Multiple Choice admin menu and submenus
- stub placeholder views for each submenu

## Testing
- `make -C tests test` *(fails: inkscape not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687fca208378832f978b4a314b1c3753