### PR TITLE
Add composer setup for wp-amc plugin

### DIFF
--- a/wp-amc/README.md
+++ b/wp-amc/README.md
@@ -1,0 +1,16 @@
+# WP-AMC Plugin
+
+This WordPress plugin integrates [Auto Multiple Choice](https://www.auto-multiple-choice.net/) features.
+
+## Installation
+
+1. From this directory, run:
+
+   ```bash
+   composer install
+   ```
+
+   This downloads the PHP dependencies defined in `composer.json`.
+
+2. Copy the plugin folder into your WordPress `wp-content/plugins` directory and activate it from the admin area.
+

--- a/wp-amc/composer.json
+++ b/wp-amc/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "auto-multiple-choice/wp-amc",
+  "description": "WordPress plugin for Auto Multiple Choice integration",
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=8.0",
+    "illuminate/database": "^10.0",
+    "twig/twig": "^3.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "wp-amc/app/"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create a `wp-amc` directory for the WordPress plugin
- add a `composer.json` with Illuminate Database and Twig dependencies
- document running `composer install` in `wp-amc/README.md`

## Testing
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_687fca2aab00832fa40cdb9c6c214b63