### PR TITLE
Add WordPress controllers for AMC scripts

### DIFF
--- a/wp-amc/app/Controllers/ExportController.php
+++ b/wp-amc/app/Controllers/ExportController.php
@@ -1,0 +1,22 @@
+<?php
+namespace WpAmc\Controllers;
+
+class ExportController
+{
+    /**
+     * Export marks for an AMC project.
+     *
+     * @param string $projectDir Path to the project directory.
+     * @param string $outputFile Destination CSV file.
+     * @return array{output:array,status:int}
+     */
+    public function exportResults(string $projectDir, string $outputFile): array
+    {
+        $command = 'AMC-export.pl --data ' . escapeshellarg($projectDir)
+            . ' --o ' . escapeshellarg($outputFile);
+        $output = [];
+        $returnVar = 0;
+        exec($command, $output, $returnVar);
+        return ['output' => $output, 'status' => $returnVar];
+    }
+}

--- a/wp-amc/app/Controllers/MailingController.php
+++ b/wp-amc/app/Controllers/MailingController.php
@@ -1,0 +1,22 @@
+<?php
+namespace WpAmc\Controllers;
+
+class MailingController
+{
+    /**
+     * Send annotated answer sheets to students via email.
+     *
+     * @param string $projectDir Path to the project directory.
+     * @param string $studentsList CSV with students emails.
+     * @return array{output:array,status:int}
+     */
+    public function sendEmails(string $projectDir, string $studentsList): array
+    {
+        $command = 'AMC-mailing.pl --project ' . escapeshellarg($projectDir)
+            . ' --students-list ' . escapeshellarg($studentsList);
+        $output = [];
+        $returnVar = 0;
+        exec($command, $output, $returnVar);
+        return ['output' => $output, 'status' => $returnVar];
+    }
+}

--- a/wp-amc/app/Controllers/PdfController.php
+++ b/wp-amc/app/Controllers/PdfController.php
@@ -1,0 +1,20 @@
+<?php
+namespace WpAmc\Controllers;
+
+class PdfController
+{
+    /**
+     * Generate PDF layout for an AMC project.
+     *
+     * @param string $projectDir Path to the project directory.
+     * @return array{output:array,status:int} Execution output and status code.
+     */
+    public function generate(string $projectDir): array
+    {
+        $command = 'AMC-meptex.pl --project ' . escapeshellarg($projectDir);
+        $output = [];
+        $returnVar = 0;
+        exec($command, $output, $returnVar);
+        return ['output' => $output, 'status' => $returnVar];
+    }
+}

--- a/wp-amc/app/Controllers/ScanController.php
+++ b/wp-amc/app/Controllers/ScanController.php
@@ -1,0 +1,22 @@
+<?php
+namespace WpAmc\Controllers;
+
+class ScanController
+{
+    /**
+     * Run OMR analysis on scanned answer sheets.
+     *
+     * @param string $projectDir Path to the project directory.
+     * @param string $scansDir Directory containing scanned sheets.
+     * @return array{output:array,status:int}
+     */
+    public function analyse(string $projectDir, string $scansDir): array
+    {
+        $command = 'AMC-analyse.pl --project ' . escapeshellarg($projectDir)
+            . ' --crdir ' . escapeshellarg($scansDir);
+        $output = [];
+        $returnVar = 0;
+        exec($command, $output, $returnVar);
+        return ['output' => $output, 'status' => $returnVar];
+    }
+}

--- a/wp-amc/app/Views/export.php
+++ b/wp-amc/app/Views/export.php
@@ -1,0 +1,6 @@
+<h1>Export Results</h1>
+<form method="post">
+    <label>Project Directory <input type="text" name="project" /></label>
+    <label>Output CSV <input type="text" name="output" /></label>
+    <button type="submit">Export Marks</button>
+</form>

--- a/wp-amc/app/Views/mailing.php
+++ b/wp-amc/app/Views/mailing.php
@@ -1,0 +1,6 @@
+<h1>Send Annotated Copies</h1>
+<form method="post">
+    <label>Project Directory <input type="text" name="project" /></label>
+    <label>Students List CSV <input type="text" name="students" /></label>
+    <button type="submit">Send Emails</button>
+</form>

--- a/wp-amc/app/Views/pdf.php
+++ b/wp-amc/app/Views/pdf.php
@@ -1,0 +1,5 @@
+<h1>PDF Generation</h1>
+<form method="post">
+    <label>Project Directory <input type="text" name="project" /></label>
+    <button type="submit">Generate PDF</button>
+</form>

--- a/wp-amc/app/Views/scan.php
+++ b/wp-amc/app/Views/scan.php
@@ -1,0 +1,6 @@
+<h1>Scan Copies</h1>
+<form method="post">
+    <label>Project Directory <input type="text" name="project" /></label>
+    <label>Scans Directory <input type="text" name="scans" /></label>
+    <button type="submit">Run Analysis</button>
+</form>


### PR DESCRIPTION
## Summary
- add controllers wrapping AMC Perl scripts
- add placeholder views for each controller

## Testing
- `make -C tests test` *(fails: `inkscape` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fca317928832f8e0f5bdca4d017a0