### PR TITLE
Remove Bug #93 workaround

### DIFF
--- a/AMC-gui.pl.in
+++ b/AMC-gui.pl.in
@@ -464,12 +464,6 @@ sub read_glade {
   return($g);
 }
 
-# As a workaround for Bug #93 these widgets are disabled when Preferences window is opened.
-# Since Bug #93 only affects Ubuntu 12.04 LTS, this workaround can be safely removed when
-# Ubuntu 12.04 LTS reaches its end of life date i.e. April 2017
-
-my @widgets_disabled_when_preferences_opened=(qw/menu_project menu_edit menu_tools menu_help/);
-
 my @widgets_only_when_opened=(qw/cleanup_menu menu_projet_enreg menu_projet_modele/);
 
 my $gui=read_glade('main_window',
@@ -493,7 +487,7 @@ my $gui=read_glade('main_window',
     config_export_modules standard_export_options
     notation_c_regroupement_type notation_c_regroupement_compose
     pref_prep_s_nombre_copies pref_prep_c_filter
-    /,@widgets_only_when_opened,@widgets_disabled_when_preferences_opened);
+    /,@widgets_only_when_opened);
 
 # Grid lines are not well-positioned in RTL environments, I don't know
 # why... so I remove them.
@@ -4147,9 +4141,6 @@ sub change_methode_impression {
 }
 
 sub edit_preferences {
-    for my $k (@widgets_disabled_when_preferences_opened) {
-      $w{$k}->set_sensitive(0);
-    }
 
     my $gap=read_glade('edit_preferences',
 		       qw/pref_projet_tous pref_projet_annonce pref_x_print_command_pdf pref_c_methode_impression email_group_sendmail email_group_SMTP/);
@@ -4204,9 +4195,6 @@ sub edit_preferences {
 
 sub closes_preferences {
   $w{'edit_preferences'}->destroy();
-  for my $k (@widgets_disabled_when_preferences_opened) {
-      $w{$k}->set_sensitive(1);
-    }
 }
 
 sub accepte_preferences {

--- a/apply_fix.py
+++ b/apply_fix.py
@@ -1,0 +1,50 @@
+import sys
+
+filename = 'AMC-gui.pl.in'
+with open(filename, 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+
+    # 1. Remove definition block (comments + definition)
+    if "# As a workaround for Bug #93" in line:
+        # We expect the next few lines to be related comments and then the definition
+        # Let's verify and skip
+        # comments are 3 lines, then blank, then definition, then blank
+        # But let's look for the definition line to stop skipping
+        found_def = False
+        j = i
+        while j < len(lines) and j < i + 10:
+            if "my @widgets_disabled_when_preferences_opened" in lines[j]:
+                found_def = True
+                break
+            j += 1
+
+        if found_def:
+            i = j + 1 # Skip until after definition
+            # Optional: skip one more if it is a blank line that was separating this block
+            if i < len(lines) and lines[i].strip() == "":
+                i += 1
+            continue
+
+    # 2. Remove usage in read_glade
+    if ",@widgets_disabled_when_preferences_opened);" in line:
+        line = line.replace(",@widgets_disabled_when_preferences_opened);", ");")
+        new_lines.append(line)
+        i += 1
+        continue
+
+    # 3. Remove loops
+    if "for my $k (@widgets_disabled_when_preferences_opened)" in line:
+        # Assume 3 lines loop
+        i += 3
+        continue
+
+    new_lines.append(line)
+    i += 1
+
+with open(filename, 'w') as f:
+    f.writelines(new_lines)


### PR DESCRIPTION
Removed the workaround for Bug #93 in AMC-gui.pl.in as Ubuntu 12.04 LTS is obsolete. This involved removing the definition of `@widgets_disabled_when_preferences_opened`, its usage in `read_glade`, and the associated loops in preference handling subroutines.

---
*PR created automatically by Jules for task [53618628350696255](https://jules.google.com/task/53618628350696255) started by @hunterd*