### PR TITLE
Verify and optimize pdftk workaround

### DIFF
--- a/AMC-imprime.pl
+++ b/AMC-imprime.pl
@@ -91,6 +91,14 @@ if(!grep(/^\Q$extract_with\E$/,@available_extracts)) {
   debug("Switching to extract engine $extract_with");
 }
 
+if($extract_with eq "pdftk+NA") {
+  my $v_pdftk=pdftk_version();
+  if($v_pdftk && $v_pdftk >= 3) {
+    debug "pdftk version $v_pdftk detected: workaround for bug #792168 not needed. Switching to standard pdftk.";
+    $extract_with="pdftk";
+  }
+}
+
 my $avance=AMC::Gui::Avancement::new($progress,'id'=>$progress_id);
 
 my $data=AMC::Data->new($data_dir);
@@ -242,3 +250,14 @@ for my $e (@es) {
 $avance->fin();
 
 
+
+sub pdftk_version {
+    return 0 if(!commande_accessible("pdftk"));
+    open(my $fh, "-|", "pdftk", "--version") or return 0;
+    my $l = <$fh>;
+    close $fh;
+    if($l =~ /pdftk\s+([0-9.]+)/i) {
+        return $1;
+    }
+    return 0;
+}

--- a/bug_report.html
+++ b/bug_report.html
@@ -1,0 +1,313 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html><head>
+<link rel="icon" href="/favicon.png">
+<title>#792168 - pdftk breaks PDF forms - Debian Bug report logs</title>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="/css/bugs.css" type="text/css">
+
+<link rel="canonical" href="&lt;a href=&quot;bugreport.cgi?bug=792168&quot;&gt;792168&lt;/a&gt;">
+<script type="text/javascript">
+<!--
+function toggle_infmessages()
+{
+        allDivs=document.getElementsByTagName("div");
+        for (var i = 0 ; i < allDivs.length ; i++ )
+        {
+                if (allDivs[i].className == "infmessage")
+                {
+                        allDivs[i].style.display=(allDivs[i].style.display == 'none' | allDivs[i].style.display == '') ? 'block' : 'none';
+                }
+        }
+}
+-->
+</script>
+</head>
+<body>
+<h1>Debian Bug report logs -
+<a href="mailto:792168@bugs.debian.org">#792168</a><br>
+pdftk breaks PDF forms</h1>
+<div class="versiongraph"><a href="version.cgi?collapse=1;found=pdftk%2F2.01-1;found=pdftk%2F2.02-4;info=1;fixed=2.02-5%2Brm;package=pdftk;absolute=0"><img alt="version graph" src="version.cgi?found=pdftk%2F2.01-1;found=pdftk%2F2.02-4;fixed=2.02-5%2Brm;width=2;height=2;package=pdftk;absolute=0;collapse=1"></a></div>
+<div class="pkginfo">
+  <p>Package:
+     <a class="submitter" href="pkgreport.cgi?package=pdftk">pdftk</a>;
+Maintainer for <a href="pkgreport.cgi?package=pdftk">pdftk</a> is <a href="pkgreport.cgi?maint=johfel%40debian.org">Johann Felix Soden &lt;johfel@debian.org&gt;</a>; Source for <a href="pkgreport.cgi?package=pdftk">pdftk</a> is <a href="pkgreport.cgi?src=pdftk">src:pdftk</a> (<a href="https://tracker.debian.org/pkg/pdftk">PTS</a>, <a href="https://buildd.debian.org/pdftk">buildd</a>, <a href="https://qa.debian.org/popcon.php?package=pdftk">popcon</a>). </p>
+
+</div>
+
+<div class="buginfo">
+  <p>Reported by: <a href="pkgreport.cgi?submitter=ghe%40sdf.org">Gregory Heytings &lt;ghe@sdf.org&gt;</a></p>
+  <p>Date: Sun, 12 Jul 2015 11:33:06 UTC</p>
+
+<p>Severity: important</p>
+<p></p>
+
+<p>Found in versions pdftk/2.01-1, pdftk/2.02-4</p>
+<p>Fixed in version 2.02-5+rm</p>
+
+<p><strong>Done:</strong> Debian FTP Masters &lt;ftpmaster@ftp-master.debian.org&gt;</p>
+
+<p>Bug is archived. No further changes may be made.<p></div>
+
+<p><input id="uselessmessages" type="checkbox"><label for="uselessmessages">Display info messages</label></p><div class="msgreceived"><p>View this report as an <a href="bugreport.cgi?bug=792168;mbox=yes">mbox folder</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;mboxstatus=yes">status mbox</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;mboxmaint=yes">maintainer mbox</a></p></div>
+
+<div class="infmessage"><hr><p>
+<a name="1"></a>
+<!-- request_addr: debian-bugs-dist@lists.debian.org, ghe@sdf.org, Johann Felix Soden &lt;johfel@debian.org&gt; -->
+<!-- time:1436700790 -->
+<strong>Report forwarded</strong>
+to <code>debian-bugs-dist@lists.debian.org, ghe@sdf.org, Johann Felix Soden &lt;johfel@debian.org&gt;</code>:<br>
+<code>Bug#792168</code>; Package <code>pdftk</code>.
+ (Sun, 12 Jul 2015 11:33:10 GMT) (<a href="bugreport.cgi?bug=792168;msg=2">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=2">mbox</a>, <a href="#1">link</a>).</p></p></div>
+
+<div class="infmessage"><hr><p>
+<a name="3"></a>
+<!-- request_addr: Gregory Heytings &lt;ghe@sdf.org&gt; -->
+<!-- time:1436700790 -->
+<strong>Acknowledgement sent</strong>
+to <code>Gregory Heytings &lt;ghe@sdf.org&gt;</code>:<br>
+New Bug report received and forwarded.  Copy sent to <code>ghe@sdf.org, Johann Felix Soden &lt;johfel@debian.org&gt;</code>.
+ (Sun, 12 Jul 2015 11:33:10 GMT) (<a href="bugreport.cgi?bug=792168;msg=4">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=4">mbox</a>, <a href="#3">link</a>).</p></p></div>
+
+<hr><p class="msgreceived"><a name="5"></a><a name="msg5"></a><a href="#5">Message #5</a> received at submit@bugs.debian.org (<a href="bugreport.cgi?bug=792168;msg=5">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=5">mbox</a>, <a href="mailto:792168@bugs.debian.org?In-Reply-To=%3Calpine.DEB.2.11.1507121323190.11363%40svobanppv.bet%3E&amp;subject=Re%3A%20pdftk%20breaks%20PDF%20forms&amp;body=On%20Sun%2C%2012%20Jul%202015%2013%3A24%3A45%20%2B0200%20%28CEST%29%20Gregory%20Heytings%20%3Cghe%40sdf.org%3E%20wrote%3A%0A%3E%20%0A%3E%20Package%3A%20pdftk%0A%3E%20Version%3A%202.01-1%0A%3E%20Severity%3A%20important%0A%3E%20%0A%3E%20Hi%2C%0A%3E%20%0A%3E%20pdftk%20%28both%201.41%20and%202.01%29%20breaks%20PDF%20forms.%0A%3E%20%0A%3E%20More%20precisely%2C%20the%20%22%2FNeedAppearances%20true%22%20entry%20in%20the%20AcroForm%20%0A%3E%20dictionary%20is%20silently%20removed%20by%20pdftk%2C%20even%20in%20a%20simple%20%22pdftk%20in.pdf%20%0A%3E%20cat%20output%20out.pdf%22%20operation.%20%20Attached%20to%20this%20report%20are%20three%20PDF%20%0A%3E%20files%3A%20%22good.pdf%22%20with%20a%20simple%20form%2C%20%22pdftk-wrong.pdf%22%20obtained%20with%20%0A%3E%20%22pdftk%20cat%20output%22%2C%20and%20%22pdftk-correct.pdf%22%20which%20is%20the%20%28corrected%20by%20%0A%3E%20hand%29%20file%20I%20would%20have%20expected%20to%20get.%0A%3E%20%0A%3E%20Note%20that%20the%20forms%20are%20only%20visible%20in%20Acrobat%20Reader.%0A%3E%20%0A%3E%20Many%20thanks%2C%0A%3E%20%0A%3E%20Gregory%0A%3E%20%0A%3E%20--%20System%20Information%3A%0A%3E%20Debian%20Release%3A%20jessie%2Fsid%0A%3E%20%20%20%20APT%20prefers%20testing%0A%3E%20%20%20%20APT%20policy%3A%20%28500%2C%20%27testing%27%29%2C%20%28500%2C%20%27stable%27%29%0A%3E%20Architecture%3A%20amd64%20%28x86_64%29%0A%3E%20Foreign%20Architectures%3A%20i386%0A%3E%20%0A%3E%20Kernel%3A%20Linux%203.2.0-4-amd64%20%28SMP%20w%2F2%20CPU%20cores%29%0A%3E%20Locale%3A%20LANG%3Den_US.ISO-8859-1%2C%20LC_CTYPE%3Den_US.ISO-8859-1%20%28charmap%3DISO-8859-1%29%0A%3E%20Shell%3A%20%2Fbin%2Fsh%20linked%20to%20%2Fbin%2Fbash%0A%3E%20%0A%3E%20Versions%20of%20packages%20pdftk%20depends%20on%3A%0A%3E%20ii%20%20libc6%20%20%20%20%20%20%202.17-97%0A%3E%20ii%20%20libgcc1%20%20%20%20%201%3A4.8.2-16%0A%3E%20ii%20%20libgcj14%20%20%20%204.8.2-16%0A%3E%20ii%20%20libstdc%2B%2B6%20%204.8.2-16%0A%3E%20%0A%3E%20pdftk%20recommends%20no%20packages.%0A%3E%20%0A%3E%20Versions%20of%20packages%20pdftk%20suggests%3A%0A%3E%20ii%20%20poppler-utils%20%5Bxpdf-utils%5D%20%200.22.5-4%0A%3E%20%0A%3E%20--%20no%20debconf%20information&amp;References=%3Calpine.DEB.2.11.1507121323190.11363%40svobanppv.bet%3E">reply</a>):</p>
+<div class="headers">
+<img src="/cgi-bin/libravatar.cgi?email=ghe%40sdf.org" alt="">
+<div class="header"><span class="headerfield">From:</span> Gregory Heytings &lt;ghe@sdf.org&gt;</div>
+<div class="header"><span class="headerfield">To:</span> Debian Bug Tracking System &lt;submit@bugs.debian.org&gt;</div>
+<div class="header"><span class="headerfield">Subject:</span> pdftk breaks PDF forms</div>
+<div class="header"><span class="headerfield">Date:</span> Sun, 12 Jul 2015 13:24:45 +0200 (CEST)</div>
+</div>
+<pre class="mime">[<a href="bugreport.cgi?att=0;bug=792168;msg=5">Message part 1</a> (text/plain, inline)]</pre>
+<pre class="message flowed">
+Package: pdftk
+Version: 2.01-1
+Severity: important
+
+Hi,
+
+pdftk (both 1.41 and 2.01) breaks PDF forms.
+
+More precisely, the &quot;/NeedAppearances true&quot; entry in the AcroForm
+dictionary is silently removed by pdftk, even in a simple &quot;pdftk in.pdf
+cat output out.pdf&quot; operation.  Attached to this report are three PDF
+files: &quot;good.pdf&quot; with a simple form, &quot;pdftk-wrong.pdf&quot; obtained with
+&quot;pdftk cat output&quot;, and &quot;pdftk-correct.pdf&quot; which is the (corrected by
+hand) file I would have expected to get.
+
+Note that the forms are only visible in Acrobat Reader.
+
+Many thanks,
+
+Gregory
+
+-- System Information:
+Debian Release: jessie/sid
+  APT prefers testing
+  APT policy: (500, &#39;testing&#39;), (500, &#39;stable&#39;)
+Architecture: amd64 (x86_64)
+Foreign Architectures: i386
+
+Kernel: Linux 3.2.0-4-amd64 (SMP w/2 CPU cores)
+Locale: LANG=en_US.ISO-8859-1, LC_CTYPE=en_US.ISO-8859-1 (charmap=ISO-8859-1)
+Shell: /bin/sh linked to /bin/bash
+
+Versions of packages pdftk depends on:
+ii  libc6       2.17-97
+ii  libgcc1     1:4.8.2-16
+ii  libgcj14    4.8.2-16
+ii  libstdc++6  4.8.2-16
+
+pdftk recommends no packages.
+
+Versions of packages pdftk suggests:
+ii  poppler-utils [xpdf-utils]  0.22.5-4
+
+-- no debconf information</pre>
+<pre class="mime">[<a href="bugreport.cgi?att=1;bug=792168;filename=good.pdf;msg=5">good.pdf</a> (application/pdf, attachment)]</pre>
+<pre class="mime">[<a href="bugreport.cgi?att=2;bug=792168;filename=pdftk-correct.pdf;msg=5">pdftk-correct.pdf</a> (application/pdf, attachment)]</pre>
+<pre class="mime">[<a href="bugreport.cgi?att=3;bug=792168;filename=pdftk-wrong.pdf;msg=5">pdftk-wrong.pdf</a> (application/pdf, attachment)]</pre>
+
+<div class="infmessage"><hr><p>
+<a name="6"></a>
+<!-- request_addr: debian-bugs-dist@lists.debian.org, Johann Felix Soden &lt;johfel@debian.org&gt; -->
+<!-- time:1489492983 -->
+<strong>Information forwarded</strong>
+to <code>debian-bugs-dist@lists.debian.org, Johann Felix Soden &lt;johfel@debian.org&gt;</code>:<br>
+<code>Bug#792168</code>; Package <code>pdftk</code>.
+ (Tue, 14 Mar 2017 12:03:03 GMT) (<a href="bugreport.cgi?bug=792168;msg=7">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=7">mbox</a>, <a href="#6">link</a>).</p></p></div>
+
+<div class="infmessage"><hr><p>
+<a name="8"></a>
+<!-- request_addr: Alexis Bienvenüe &lt;pado@passoire.fr&gt; -->
+<!-- time:1489492983 -->
+<strong>Acknowledgement sent</strong>
+to <code>Alexis Bienvenüe &lt;pado@passoire.fr&gt;</code>:<br>
+Extra info received and forwarded to list.  Copy sent to <code>Johann Felix Soden &lt;johfel@debian.org&gt;</code>.
+ (Tue, 14 Mar 2017 12:03:03 GMT) (<a href="bugreport.cgi?bug=792168;msg=9">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=9">mbox</a>, <a href="#8">link</a>).</p></p></div>
+
+<hr><p class="msgreceived"><a name="10"></a><a name="msg10"></a><a href="#10">Message #10</a> received at 792168@bugs.debian.org (<a href="bugreport.cgi?bug=792168;msg=10">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=10">mbox</a>, <a href="mailto:792168@bugs.debian.org?In-Reply-To=%3C148949184185.10238.6271614473565999282.reportbug%40poirier.univ-lyon1.fr%3E&amp;References=%3C148949184185.10238.6271614473565999282.reportbug%40poirier.univ-lyon1.fr%3E&amp;subject=Re%3A%20pdftk%20breaks%20PDF%20forms&amp;body=On%20Tue%2C%2014%20Mar%202017%2012%3A44%3A01%20%2B0100%20%3D%3Futf-8%3Fq%3FAlexis_Bienven%3DC3%3DBCe%3F%3D%20%3Cpado%40passoire.fr%3E%20wrote%3A%0A%3E%20Package%3A%20pdftk%0A%3E%20Version%3A%202.02-4%2Bb2%0A%3E%20Followup-For%3A%20Bug%20%23792168%0A%3E%20%0A%3E%20Dear%20Maintainer%2C%0A%3E%20%0A%3E%20The%20problem%20also%20exists%20with%20forms%20that%20can%20be%20used%20with%20evince%2Fokular.%0A%3E%20With%20attached%20LaTeX%20file%20using%20hyperref%20package%2C%20you%20can%20build%20such%20a%20form%3A%0A%3E%20%0A%3E%20pdflatex%20sample.tex%0A%3E%20evince%20small.pdf%0A%3E%20%0A%3E%20Extracting%20pages%20with%20pdftk%20breaks%20the%20form%3A%20when%20clicking%20on%20the%20box%20in%20the%0A%3E%20new%20PDF%20form%2C%20the%20box%20disappears%20instead%20of%20showing%20a%20%22checked%22%20symbol.%0A%3E%20%0A%3E%20pdftk%20small.pdf%20cat%20output%20small-all.pdf%0A%3E%20evince%20small-all.pdf%0A%3E%20%0A%3E%20However%2C%20as%20a%20workaround%2C%20you%20can%20fix%20this%20file%20with%0A%3E%20%0A%3E%20pdftk%20small-all.pdf%20output%20small-all-fixed.pdf%20need_appearances%0A%3E%20%0A%3E%20Note%20that%20the%20file%20produced%20with%0A%3E%20pdftk%20small.pdf%20cat%20output%20small-all.pdf%20need_appearances%0A%3E%20does%20show%20the%20problem.%0A%3E%20%0A%3E%20Regards%2C%0A%3E%20Alexis%20Bienven%C3%BCe.%0A%3E%20%0A%3E%20%0A%3E%20%0A%3E%20--%20System%20Information%3A%0A%3E%20Debian%20Release%3A%209.0%0A%3E%20%20%20APT%20prefers%20testing%0A%3E%20%20%20APT%20policy%3A%20%28990%2C%20%27testing%27%29%2C%20%28800%2C%20%27experimental%27%29%2C%20%28800%2C%20%27unstable%27%29%0A%3E%20Architecture%3A%20amd64%20%28x86_64%29%0A%3E%20Foreign%20Architectures%3A%20i386%0A%3E%20%0A%3E%20Kernel%3A%20Linux%204.9.0-1-amd64%20%28SMP%20w%2F4%20CPU%20cores%29%0A%3E%20Locale%3A%20LANG%3Dfr_FR.utf8%2C%20LC_CTYPE%3Dfr_FR.utf8%20%28charmap%3DUTF-8%29%0A%3E%20Shell%3A%20%2Fbin%2Fsh%20linked%20to%20%2Fbin%2Fdash%0A%3E%20Init%3A%20systemd%20%28via%20%2Frun%2Fsystemd%2Fsystem%29%0A%3E%20%0A%3E%20Versions%20of%20packages%20pdftk%20depends%20on%3A%0A%3E%20ii%20%20libc6%20%20%20%20%20%20%202.24-9%0A%3E%20ii%20%20libgcc1%20%20%20%20%201%3A6.3.0-6%0A%3E%20ii%20%20libgcj17%20%20%20%206.3.0-6%0A%3E%20ii%20%20libstdc%2B%2B6%20%206.3.0-6%0A%3E%20%0A%3E%20pdftk%20recommends%20no%20packages.%0A%3E%20%0A%3E%20Versions%20of%20packages%20pdftk%20suggests%3A%0A%3E%20ii%20%20poppler-utils%20%5Bxpdf-utils%5D%20%200.48.0-2%0A%3E%20%0A%3E%20--%20no%20debconf%20information%0A">reply</a>):</p>
+<div class="headers">
+<img src="/cgi-bin/libravatar.cgi?email=pado%40passoire.fr" alt="">
+<div class="header"><span class="headerfield">From:</span> Alexis Bienvenüe &lt;pado@passoire.fr&gt;</div>
+<div class="header"><span class="headerfield">To:</span> Debian Bug Tracking System &lt;792168@bugs.debian.org&gt;</div>
+<div class="header"><span class="headerfield">Subject:</span> Re: pdftk breaks PDF forms</div>
+<div class="header"><span class="headerfield">Date:</span> Tue, 14 Mar 2017 12:44:01 +0100</div>
+</div>
+<pre class="mime">[<a href="bugreport.cgi?att=0;bug=792168;msg=10">Message part 1</a> (text/plain, inline)]</pre>
+<pre class="message">Package: pdftk
+Version: 2.02-4+b2
+Followup-For: Bug #792168
+
+Dear Maintainer,
+
+The problem also exists with forms that can be used with evince/okular.
+With attached LaTeX file using hyperref package, you can build such a form:
+
+pdflatex sample.tex
+evince small.pdf
+
+Extracting pages with pdftk breaks the form: when clicking on the box in the
+new PDF form, the box disappears instead of showing a &quot;checked&quot; symbol.
+
+pdftk small.pdf cat output small-all.pdf
+evince small-all.pdf
+
+However, as a workaround, you can fix this file with
+
+pdftk small-all.pdf output small-all-fixed.pdf need_appearances
+
+Note that the file produced with
+pdftk small.pdf cat output small-all.pdf need_appearances
+does show the problem.
+
+Regards,
+Alexis Bienvenüe.
+
+
+
+-- System Information:
+Debian Release: 9.0
+  APT prefers testing
+  APT policy: (990, &#39;testing&#39;), (800, &#39;experimental&#39;), (800, &#39;unstable&#39;)
+Architecture: amd64 (x86_64)
+Foreign Architectures: i386
+
+Kernel: Linux 4.9.0-1-amd64 (SMP w/4 CPU cores)
+Locale: LANG=fr_FR.utf8, LC_CTYPE=fr_FR.utf8 (charmap=UTF-8)
+Shell: /bin/sh linked to /bin/dash
+Init: systemd (via /run/systemd/system)
+
+Versions of packages pdftk depends on:
+ii  libc6       2.24-9
+ii  libgcc1     1:6.3.0-6
+ii  libgcj17    6.3.0-6
+ii  libstdc++6  6.3.0-6
+
+pdftk recommends no packages.
+
+Versions of packages pdftk suggests:
+ii  poppler-utils [xpdf-utils]  0.48.0-2
+
+-- no debconf information
+</pre>
+<pre class="mime">[<a href="bugreport.cgi?att=1;bug=792168;filename=small.tex;msg=10">small.tex</a> (text/plain, attachment)]</pre>
+<pre class="mime">[<a href="bugreport.cgi?att=2;bug=792168;filename=small-all.pdf;msg=10">small-all.pdf</a> (application/pdf, attachment)]</pre>
+
+<div class="msgreceived"><hr><p>
+<a name="11"></a>
+<!-- request_addr: Debian FTP Masters &lt;ftpmaster@ftp-master.debian.org&gt; -->
+<!-- time:1690562407 -->
+<strong>Reply sent</strong>
+to <code>Debian FTP Masters &lt;ftpmaster@ftp-master.debian.org&gt;</code>:<br>
+You have taken responsibility.
+ (Fri, 28 Jul 2023 16:40:07 GMT) (<a href="bugreport.cgi?bug=792168;msg=12">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=12">mbox</a>, <a href="#11">link</a>).</p></p></div>
+
+<div class="infmessage"><hr><p>
+<a name="13"></a>
+<!-- request_addr: Gregory Heytings &lt;ghe@sdf.org&gt; -->
+<!-- time:1690562407 -->
+<strong>Notification sent</strong>
+to <code>Gregory Heytings &lt;ghe@sdf.org&gt;</code>:<br>
+Bug acknowledged by developer.
+ (Fri, 28 Jul 2023 16:40:07 GMT) (<a href="bugreport.cgi?bug=792168;msg=14">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=14">mbox</a>, <a href="#13">link</a>).</p></p></div>
+
+<hr><p class="msgreceived"><a name="15"></a><a name="msg15"></a><a href="#15">Message #15</a> received at 792168-done@bugs.debian.org (<a href="bugreport.cgi?bug=792168;msg=15">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=15">mbox</a>, <a href="mailto:792168@bugs.debian.org?In-Reply-To=%3CE1qPQSm-00EvB1-Re%40fasolo.debian.org%3E&amp;References=%3CE1qPQSm-00EvB1-Re%40fasolo.debian.org%3E&amp;subject=Re%3A%20Bug%231032736%3A%20Removed%20package%28s%29%20from%20unstable&amp;body=On%20Fri%2C%2028%20Jul%202023%2016%3A37%3A12%20%2B0000%20Debian%20FTP%20Masters%20%3Cftpmaster%40ftp-master.debian.org%3E%20wrote%3A%0A%3E%20Version%3A%202.02-5%2Brm%0A%3E%20%0A%3E%20Dear%20submitter%2C%0A%3E%20%0A%3E%20as%20the%20package%20pdftk%20has%20just%20been%20removed%20from%20the%20Debian%20archive%0A%3E%20unstable%20we%20hereby%20close%20the%20associated%20bug%20reports.%20%20We%20are%20sorry%0A%3E%20that%20we%20couldn%27t%20deal%20with%20your%20issue%20properly.%0A%3E%20%0A%3E%20For%20details%20on%20the%20removal%2C%20please%20see%20https%3A%2F%2Fbugs.debian.org%2F1032736%0A%3E%20%0A%3E%20The%20version%20of%20this%20package%20that%20was%20in%20Debian%20prior%20to%20this%20removal%0A%3E%20can%20still%20be%20found%20using%20https%3A%2F%2Fsnapshot.debian.org%2F.%0A%3E%20%0A%3E%20Please%20note%20that%20the%20changes%20have%20been%20done%20on%20the%20master%20archive%20and%0A%3E%20will%20not%20propagate%20to%20any%20mirrors%20until%20the%20next%20dinstall%20run%20at%20the%0A%3E%20earliest.%0A%3E%20%0A%3E%20This%20message%20was%20generated%20automatically%3B%20if%20you%20believe%20that%20there%20is%0A%3E%20a%20problem%20with%20it%20please%20contact%20the%20archive%20administrators%20by%20mailing%0A%3E%20ftpmaster%40ftp-master.debian.org.%0A%3E%20%0A%3E%20Debian%20distribution%20maintenance%20software%0A%3E%20pp.%0A%3E%20Scott%20Kitterman%20%28the%20ftpmaster%20behind%20the%20curtain%29%0A%3E%20%0A%3E%20%0A">reply</a>):</p>
+<div class="headers">
+<img src="/cgi-bin/libravatar.cgi?email=ftpmaster%40ftp-master.debian.org" alt="">
+<div class="header"><span class="headerfield">From:</span> Debian FTP Masters &lt;ftpmaster@ftp-master.debian.org&gt;</div>
+<div class="header"><span class="headerfield">To:</span> 409613-done@bugs.debian.org,421343-done@bugs.debian.org,476933-done@bugs.debian.org,548876-done@bugs.debian.org,563463-done@bugs.debian.org,610394-done@bugs.debian.org,619184-done@bugs.debian.org,660089-done@bugs.debian.org,661604-done@bugs.debian.org,693723-done@bugs.debian.org,698826-done@bugs.debian.org,703377-done@bugs.debian.org,728242-done@bugs.debian.org,769480-done@bugs.debian.org,788660-done@bugs.debian.org,792168-done@bugs.debian.org,799526-done@bugs.debian.org,819413-done@bugs.debian.org,824110-done@bugs.debian.org,839188-done@bugs.debian.org,892539-done@bugs.debian.org,901761-done@bugs.debian.org,906011-done@bugs.debian.org,</div>
+<div class="header"><span class="headerfield">Cc:</span> pdftk@packages.debian.org</div>
+<div class="header"><span class="headerfield">Subject:</span> Bug#1032736: Removed package(s) from unstable</div>
+<div class="header"><span class="headerfield">Date:</span> Fri, 28 Jul 2023 16:37:12 +0000</div>
+</div>
+<pre class="message">Version: 2.02-5+rm
+
+Dear submitter,
+
+as the package pdftk has just been removed from the Debian archive
+unstable we hereby close the associated bug reports.  We are sorry
+that we couldn&#39;t deal with your issue properly.
+
+For details on the removal, please see <a href="https://bugs.debian.org/1032736">https://bugs.debian.org/1032736</a>
+
+The version of this package that was in Debian prior to this removal
+can still be found using <a href="https://snapshot.debian.org/">https://snapshot.debian.org/</a>.
+
+Please note that the changes have been done on the master archive and
+will not propagate to any mirrors until the next dinstall run at the
+earliest.
+
+This message was generated automatically; if you believe that there is
+a problem with it please contact the archive administrators by mailing
+ftpmaster@ftp-master.debian.org.
+
+Debian distribution maintenance software
+pp.
+Scott Kitterman (the ftpmaster behind the curtain)
+
+
+</pre>
+
+<div class="msgreceived"><hr><p>
+<a name="16"></a>
+<!-- command:archive -->
+<!-- requester: Debbugs Internal Request &lt;owner@bugs.debian.org&gt; -->
+<!-- request_addr: internal_control@bugs.debian.org -->
+<!-- time:1693035220 -->
+<!-- new_data:
+$new_data = {};
+-->
+<!-- old_data:
+$old_data = {};
+-->
+<strong>Bug archived.</strong>
+Request was from <code>Debbugs Internal Request &lt;owner@bugs.debian.org&gt;</code>
+to <code>internal_control@bugs.debian.org</code>.
+ (Sat, 26 Aug 2023 07:33:40 GMT) (<a href="bugreport.cgi?bug=792168;msg=17">full text</a>, <a href="bugreport.cgi?bug=792168;mbox=yes;msg=17">mbox</a>, <a href="#16">link</a>).</p></p></div>
+
+<hr>
+<p class="msgreceived">Send a report that <a href="https://bugs.debian.org/cgi-bin/bugspam.cgi?bug=792168">this bug log contains spam</a>.</p>
+<hr>
+<ADDRESS>Debian bug tracking system administrator &lt;<A HREF="mailto:owner@bugs.debian.org">owner@bugs.debian.org</A>&gt;.
+Last modified:
+<!--timestamp-->Thu Feb  5 19:15:23 2026<!--end timestamp-->;
+Machine Name:
+<!--machinename-->berlioz<!--machinename-->
+<P>
+<A HREF="https://www.debian.org/Bugs/">Debian Bug tracking system</A>
+</p>
+<p>
+  Debbugs is free software and licensed under the terms of the GNU General
+  Public License version 2. The current version can be obtained
+  from <a href="https://bugs.debian.org/debbugs-source/">https://bugs.debian.org/debbugs-source/</a>.
+</p>
+<p>
+Copyright © 1999 Darren O. Benham,
+1997,2003 nCipher Corporation Ltd,
+1994-97 Ian Jackson,
+2005-2017 Don Armstrong, and many other contributors.
+</p>
+</ADDRESS>
+
+</body>
+</html>


### PR DESCRIPTION
Verified that Debian bug #792168 is fixed in pdftk-java (version 3.x).
Added logic to AMC-imprime.pl to check pdftk version.
If pdftk version is >= 3.0, automatically switch from 'pdftk+NA' to standard 'pdftk', avoiding the redundant 'need_appearances' step.
This preserves the workaround for older versions while optimizing for modern ones.

---
*PR created automatically by Jules for task [11706136185891101829](https://jules.google.com/task/11706136185891101829) started by @hunterd*