### PR TITLE
Fix typo in AMC/Annotate.pm

### DIFF
--- a/AMC-perl/AMC/Annotate.pm
+++ b/AMC-perl/AMC/Annotate.pm
@@ -105,7 +105,7 @@ sub new {
       $self->{position}='none';
     }
 
-    # chacks that the embedded_format is ok
+    # checks that the embedded_format is ok
     $self->{embedded_format}=lc($self->{embedded_format});
     if($self->{embedded_format} !~ /^(jpeg|png)$/i) {
       debug "ERROR: invalid <embedded_format>: $self->{embedded_format}";


### PR DESCRIPTION
Corrected a spelling error in a comment within `AMC-perl/AMC/Annotate.pm`. The word 'chacks' was corrected to 'checks'. Verified the change manually.

---
*PR created automatically by Jules for task [13158100589231873916](https://jules.google.com/task/13158100589231873916) started by @hunterd*