### PR TITLE
Remove unused variable in AMC/Annotate.pm

### DIFF
--- a/AMC-perl/AMC/Annotate.pm
+++ b/AMC-perl/AMC/Annotate.pm
@@ -258,7 +258,6 @@ sub pdf_output_filename {
     my $i=$self->{association}->get_real(@$student);
     $self->{data}->end_transaction('rAGN');
 
-    my $name='XXX';
     my $n;
 
     debug "Association -> ID=$i";


### PR DESCRIPTION
The variable $name was initialized but never used in the code. It has been removed to clean up the code.

---
*PR created automatically by Jules for task [3348569727168886939](https://jules.google.com/task/3348569727168886939) started by @hunterd*